### PR TITLE
Add option to include multiple transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,27 @@ module.exports.log = {
   },
 
   // unlock mongoDB transport!
-  // more information: https://github.com/winstonjs/winston#mongodb-transport
+  // more information: https://github.com/winstonjs/winston/blob/master/docs/transports.md#mongodb-transport
   mongoDB: {
     level: 'silly',
     db: pkgJSON.name,
     collection: 'logs',
     host: 'localhost',
     port: 27017
-  }
+  },
+
+  // Add more transports
+  // see here for more: https://github.com/winstonjs/winston/blob/master/docs/transports.md
+  transports: [
+    {
+      module: require('winston-logio').Logio,
+      config: {
+        port: 28777,
+        node_name: pkgJSON.name,
+        host: '127.0.0.1'
+      }
+    }
+  ]
 };
 ```
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,13 @@ module.exports = function(sails) {
         logger.add(require('winston-mongodb').MongoDB, sails.config.log.mongoDB);
       }
 
+      // Add more transports, see here for more https://github.com/winstonjs/winston/blob/master/docs/transports.md
+      if (Object.prototype.toString.call(sails.config.log.transports) === '[object Array]' && sails.config.log.transports.length > 0) {
+        sails.config.log.transports.forEach(function (transport) {
+          logger.add(transport.module, transport.config || {});
+        });
+      }
+
       sails.config.log.custom = logger;
 
       log = captain(sails.config.log);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "mkdirp": "*",
+    "winston": "*",
     "winston-mongodb": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Add custom transport in config options, by example:  
`$ npm install --save winston-logio`  
Then  

```
// config/log.js
module.exports.log = {
  // level: 'silly',
  transports: [
    {
      module: require('winston-logio').Logio,
      config: {
        port: 28777,
        node_name: require('../package.json').name,
        host: '127.0.0.1',
        level: 'verbose'
      }
    }
  ]

};
```
