### PR TITLE
Fix: pass winston instance to captains log

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function(sails) {
       var log;
       var logger;
       var consoleOptions;
+      var captainsOptions = sails.config.log;
 
       consoleOptions = {
         level: sails.config.log.level,
@@ -54,7 +55,8 @@ module.exports = function(sails) {
 
       sails.config.log.custom = logger;
 
-      log = captain(sails.config.log);
+      captainsOptions.custom = logger;
+      log = captain(captainsOptions);
       log.ship = buildShipFn(sails.version ? ('v' + sails.version) : '', log.info);
       sails.log = log;
       return done();


### PR DESCRIPTION
In order for the sails logger `captains-log` to log to winston it requires the winston instance to be passed to it.

As documented here:
https://github.com/balderdashy/captains-log#using-winston
