### PR TITLE
Feature: simplify transports config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ At this moment, the transport supported are:
 
 - Console (by default based in the Sails log options).
 - [DailyLogRotate](https://github.com/winstonjs/winston#daily-rotate-file-transport).
-- [MongoDB](https://github.com/winstonjs/winston#mongodb-transport).
 - [Customs Transports](https://github.com/winstonjs/winston/blob/master/docs/transports.md).
 
 ## API
@@ -49,16 +48,6 @@ module.exports.log = {
     prettyPrint: true,
     timestamp: true,
     level: 'silly'
-  },
-
-  // unlock mongoDB transport!
-  // more information: https://github.com/winstonjs/winston/blob/master/docs/transports.md#mongodb-transport
-  mongoDB: {
-    level: 'silly',
-    db: pkgJSON.name,
-    collection: 'logs',
-    host: 'localhost',
-    port: 27017
   },
 
   // unlock custom transport!

--- a/README.md
+++ b/README.md
@@ -17,13 +17,10 @@ npm install sails-hook-winston
 ```
 ## Usage
 
-[winston](https://github.com/winstonjs/winston) is one of the most powerful logging libraries for NodeJS. You can unlock the feature of winston in your Sails application when you use this hook, in special use different transport.
+[winston](https://github.com/winstonjs/winston) is one of the most powerful logging libraries for NodeJS. You can unlock the features of winston in your Sails application when you use this hook.
 
-At this moment, the transport supported are:
-
-- Console (by default based in the Sails log options).
-- [DailyLogRotate](https://github.com/winstonjs/winston#daily-rotate-file-transport).
-- [Customs Transports](https://github.com/winstonjs/winston/blob/master/docs/transports.md).
+All [available winston transports](https://github.com/winstonjs/winston/blob/master/docs/transports.md) can be configured through the `transports` option.
+The console transport is included by default (by default based on the Sails log options).
 
 ## API
 
@@ -39,20 +36,20 @@ module.exports.log = {
   level: 'silly', // you are familiar with this value, right?
   timestamp: true, // if you want to output the timestamp in the console transport
 
-  // unlock dailyRorate transport!
-  // more information: https://github.com/winstonjs/winston#daily-rotate-file-transport
-  dailyRotate: {
-    dirname: path.resolve('logs'),
-    datePattern: '.yyyy-MM-dd.log',
-    filename: pkgJSON.name,
-    prettyPrint: true,
-    timestamp: true,
-    level: 'silly'
-  },
-
-  // unlock custom transport!
+  // Transports
   // more information: https://github.com/winstonjs/winston/blob/master/docs/transports.md
   transports: [
+    {
+      module: require('winston-daily-rotate-file'),
+      config: {
+        dirname: path.resolve('logs'),
+        datePattern: '.yyyy-MM-dd.log',
+        filename: pkgJSON.name,
+        prettyPrint: true,
+        timestamp: true,
+        level: 'silly'
+      }
+    },
     {
       module: require('winston-logio').Logio,
       config: {
@@ -65,7 +62,7 @@ module.exports.log = {
 };
 ```
 
-Note how the options are different for each transport. For example, you can use `info` level in console but store `silly` level in MongoDB.
+Note how the options are different for each transport. For example, you can use `info` level in console but store `silly` level in DailyFileRotate.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -34,12 +34,6 @@ module.exports = function(sails) {
       // Console Transport
       logger = new winston.Logger({transports: [new winston.transports.Console(consoleOptions)]});
 
-      // DailyRotateFile Transport
-      if (sails.config.log.dailyRotate) {
-        mkdirp.sync(sails.config.log.dailyRotate.dirname);
-        logger.add(require('winston-daily-rotate-file'), (sails.config.log.dailyRotate));
-      }
-
       // Custom Transport
       // More information: https://github.com/winstonjs/winston/blob/master/docs/transports.md
       if (Object.prototype.toString.call(sails.config.log.transports) === '[object Array]' && sails.config.log.transports.length > 0) {

--- a/index.js
+++ b/index.js
@@ -40,10 +40,6 @@ module.exports = function(sails) {
         logger.add(require('winston-daily-rotate-file'), (sails.config.log.dailyRotate));
       }
 
-      // MongoDB Transport
-      if (sails.config.log.mongoDB)
-        logger.add(require('winston-mongodb').MongoDB, sails.config.log.mongoDB);
-
       // Custom Transport
       // More information: https://github.com/winstonjs/winston/blob/master/docs/transports.md
       if (Object.prototype.toString.call(sails.config.log.transports) === '[object Array]' && sails.config.log.transports.length > 0) {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   },
   "dependencies": {
     "mkdirp": "*",
-    "winston": "^2.1.0",
-    "winston-daily-rotate-file": "^1.0.1"
+    "winston": "^2.1.0"
   },
   "devDependencies": {
     "sails": "~0.11.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "mkdirp": "*",
     "winston": "^2.1.0",
-    "winston-daily-rotate-file": "^1.0.1",
-    "winston-mongodb": "*"
+    "winston-daily-rotate-file": "^1.0.1"
   },
   "devDependencies": {
     "sails": "~0.11.0",


### PR DESCRIPTION
Including specific transports as dependencies is inflexible, focusing on the custom transports config will keep the hook lightweight so users can add the transports they require.

Resolves #5 
