### PR TITLE
Follow sails log level priority

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,17 @@ export default function (sails) {
       };
 
       // Console Transport
-      logger = new winston.Logger({transports: [new winston.transports.Console(consoleOptions)]});
+      logger = new winston.Logger({
+        transports: [new winston.transports.Console(consoleOptions)],
+        levels: {
+          error: 1,
+          warn: 2,
+          debug: 3,
+          info: 4,
+          verbose: 5,
+          silly: 6
+        }
+      });
 
       // Custom Transport
       // More information: https://github.com/winstonjs/winston/blob/master/docs/transports.md

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -1,5 +1,6 @@
 import { Sails } from 'sails';
 import hook from '../../src/index';
+import { expect } from 'chai';
 
 describe('Basic tests', () => {
   let sails;
@@ -28,5 +29,16 @@ describe('Basic tests', () => {
 
   it('Should properly start sails application', () => {
     return true;
+  });
+
+  it('Should follow sails default log level priority', () => {
+    expect(sails.config.log.custom.levels).to.eql({
+      error: 1,
+      warn: 2,
+      debug: 3,
+      info: 4,
+      verbose: 5,
+      silly: 6
+    });
   });
 });


### PR DESCRIPTION
This fixes issue #10.

sails-hook-winston currently uses the winston default log levels:

``` js
{ error: 1, warn: 2, info: 3, verbose: 4, debug: 5, silly: 6 }
```

However, sails uses a slightly different convention for its log levels:

``` js
{ error: 1, warn: 2, debug: 3, info: 4, verbose: 5, silly: 6 }
```

(note that the order of `info`, `verbose`, and `debug` are different)

This was causing an issue where sails-hook-winston was changing the log priority. For example, with log level set to `info`, using `sails.log.debug` generates output in the absence of sails-hook-winston, but it does not generate output when sails-hook-winston is used. This occurs because the `debug` log level is higher than the `info` level with the winston default, but it is lower with the sails convention.

This fix changes sails-hook-winston's logger to use the normal sails log levels.
